### PR TITLE
disable numjs to avoid extra dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The plots below show performance on an Apple M1 (15w passively cooled MacBook Ai
 This is a simple node.js function that you can replicate on your own computer:
 
 ```
-$ npm install gifti-reader-js atob numjs pako buffer
+$ npm install gifti-reader-js atob pako buffer
 $ git clone https://github.com/neurolabusc/MeshFormatsJS.git
 $ cd MeshFormatsJS
 $ node ./meshtest.js

--- a/lib/jdata.js
+++ b/lib/jdata.js
@@ -23,16 +23,18 @@ class jdata{
       this._zipper = (typeof pako !== 'undefined'
         ? pako
         : require('pako'));
-      this._nj = (typeof nj !== 'undefined'
-        ? nj
-        : require('numjs'));
-      this._nj.NdArray.prototype.toJSON = function(){
-            return JSON.stringify(this.tolist(),function(k,v){
-            if (typeof v === 'bigint')
-                return '~~'+v.toString()+'~~';
-            return v;
-           });
-        };
+      if(options.hasOwnProperty('usenumjs') && options['usenumjs']==1){
+        this._nj = (typeof nj !== 'undefined'
+          ? nj
+          : require('numjs'));
+        this._nj.NdArray.prototype.toJSON = function(){
+              return JSON.stringify(this.tolist(),function(k,v){
+              if (typeof v === 'bigint')
+                  return '~~'+v.toString()+'~~';
+              return v;
+             });
+          };
+       }
     }
     
     encode(){

--- a/meshtest.js
+++ b/meshtest.js
@@ -209,7 +209,7 @@ async function main() {
         indices = gii.getTrianglesDataArray().getData();
       }
       if (ext.toUpperCase() === "JMSH") {
-        var jmsh = new jd(JSON.parse(fs.readFileSync(fnm).toString().replace(/\n/g,'')));
+        var jmsh = new jd(JSON.parse(fs.readFileSync(fnm).toString().replace(/\n/g,'')), {usenumjs:false});
         jmsh=jmsh.decode();
         points = jmsh.data.MeshVertex3;
         indices = jmsh.data.MeshTri3;
@@ -220,7 +220,7 @@ async function main() {
           points = jmsh[0].MeshVertex3;
           indices = jmsh[0].MeshTri3;
         }else{
-          jmsh=new jd(jmsh[0]).decode();
+          jmsh=new jd(jmsh[0], {usenumjs:false}).decode();
           points = jmsh.data.MeshVertex3;
           indices = jmsh.data.MeshTri3;
         }


### PR DESCRIPTION
hi @neurolabusc, from reading/using the [minimized numjs.min.js](https://cdnjs.cloudflare.com/ajax/libs/numjs/0.16.0/numjs.min.js), I did not notice a lot of dependencies, so I am a bit surprised that npm installed a load of stuff when installing it.

anyways, I've changed jdata.js to disable numjs to avoid this unnecessary burden (here we only use the decoder part) - after decoding, ND-array will be stored in a 1D TypedArray buffer.

also, I tested it on a Linux box with an Intel i7-7700K CPU, it is similar to the ones you've already posted
```
fangq@taote:~/space/git/Temp/MeshFormatsJS$ node ./meshtest.js
gz.gii	Size	4384750	Time	1952
gz.mz3	Size	3259141	Time	520
raw.mz3	Size	5898280	Time	22
obj.obj	Size	13307997	Time	5686
stl.stl	Size	16384084	Time	166
zlib.jmsh	Size	4405604	Time	609
zlib.bmsh	Size	3259049	Time	474
raw.min.json	Size	12325881	Time	1400
raw.bmsh	Size	5898902	Time	25
Done
```
```
fangq@taote:~/space/git/Temp/MeshFormatsJS$ lscpu | grep Model
Model:               158
Model name:          Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz
```
