### PR TITLE
accept {zlib:'fflate'} to get faster jdata unzip/ungzip speed

### DIFF
--- a/lib/jdata.js
+++ b/lib/jdata.js
@@ -60,6 +60,8 @@ class jdata{
     zip(buf, method){
         if(method!=='zlib' || method!=='gzip')
             method='zlib';
+        if(typeof this._zipper.compressSync === 'function')
+            return btoa(this._zipper.compressSync(str));
         if(method==='zlib')
             return btoa(this._zipper.deflate(new Uint8Array(buf), { to: 'string' }));
         else if(method==='gzip')
@@ -67,6 +69,8 @@ class jdata{
     }
     
     unzip(str, method){
+        if(typeof this._zipper.decompressSync === 'function')
+            return this._zipper.decompressSync(str);
         if(method==='zlib')
             return this._zipper.inflate(str);
         else if(method==='gzip')

--- a/meshtest.js
+++ b/meshtest.js
@@ -197,7 +197,7 @@ async function main() {
         indices = gii.getTrianglesDataArray().getData();
       }
       if (ext.toUpperCase() === "JMSH") {
-        var jmsh = new jd(JSON.parse(fs.readFileSync(fnm).toString().replace(/\n/g,'')), {usenumjs:false});
+        var jmsh = new jd(JSON.parse(fs.readFileSync(fnm).toString().replace(/\n/g,'')), {usenumjs:false, zlib:'fflate'});
         jmsh=jmsh.decode();
         points = jmsh.data.MeshVertex3;
         indices = jmsh.data.MeshTri3;
@@ -212,7 +212,7 @@ async function main() {
           points = jmsh.data.MeshVertex3;
           indices = jmsh.data.MeshTri3;
         }else{
-          jmsh=new jd(jmsh[0], {usenumjs:false}).decode();
+          jmsh=new jd(jmsh[0], {usenumjs:false, zlib:'fflate'}).decode();
           points = jmsh.data.MeshVertex3;
           indices = jmsh.data.MeshTri3;
         }


### PR DESCRIPTION
great find @neurolabusc for the `fflate` module. it indeed improves jmsh/bmsh decoding as well. using my desktop at work (Intel i7-7700K, Ubuntu 18.04), the new module shaved about 150 ms (25%) from both jmsh and bmsh loading times
```
pako:
zlib.jmsh	Size	4405604	Time	646
zlib.bmsh	Size	3259049	Time	497

fflate
zlib.jmsh	Size	4405604	Time	493
zlib.bmsh	Size	3259049	Time	355
```