### PR TITLE
Add python file parsing and benchmarking scripts

### DIFF
--- a/matlab/meshtest.m
+++ b/matlab/meshtest.m
@@ -42,7 +42,7 @@ function res=meshtest(doplot)
 %
 
 path='../meshes';
-files={'gz.gii', 'gz.mz3', 'raw.mz3', 'obj.obj', 'stl.stl', 'zlib.jmsh', 'zlib.bmsh', 'raw.min.json', 'raw.bmsh', 'lzma.bmsh'};
+files={'obj.obj', 'gz.gii',  'raw.gii', 'ply.ply', 'gz.mz3', 'raw.mz3',  'stl.stl', 'zlib.jmsh', 'zlib.bmsh', 'raw.min.json', 'raw.bmsh', 'lzma.bmsh'};
 expectednode=[163842 3];
 expectedface=[327680 3];
 
@@ -90,6 +90,9 @@ fc=data.faces;
 
 function [no,fc]=testmz3(fname)
 [fc,no] = readMz3(fname);
+
+function [no,fc]=testply(fname)
+[fc,no] = readPly(fname);
 
 function [no,fc]=teststl(fname)
 [no, fc] = stlread(fname);

--- a/matlab/private/readMz3.m
+++ b/matlab/private/readMz3.m
@@ -1,5 +1,5 @@
-function [faces, vertices, vertexColors, data] = readMz3(filename)
-%function [faces, vertices, vertexColors, data] = readMz3(fileName)
+function [faces, vertices, vertexColors] = readMz3(filename)
+%function [faces, vertices, vertexColors] = readMz3(fileName)
 %inputs:
 %	filename: the nv file to open
 %outputs:
@@ -12,13 +12,12 @@ function [faces, vertices, vertexColors, data] = readMz3(filename)
 faces = [];
 vertices = [];
 vertexColors = [];
-data = [];
 if ~exist(filename,'file'), error('Unable to find MZ3 file named "%s"', filename); return; end;
 fid = fopen(filename,'r','ieee-le');
 magic = fread(fid, 1, 'uint16');
 if (magic ~= 23117) 
     fclose(fid);
-    [faces, vertices, vertexColors, data] = readMz3Gz(filename);
+    [faces, vertices, vertexColors] = readMz3Gz(filename);
     return;
 end
 attr = fread(fid, 1, 'uint16');
@@ -61,8 +60,8 @@ fclose(fid);
 %end readMz3()
 
 
-function [faces, vertices, vertexColors, data] = readMz3Gz(filename)
-%function [faces, vertices, vertexColors, data] = readMz3(fileName)
+function [faces, vertices, vertexColors] = readMz3Gz(filename)
+%function [faces, vertices, vertexColors] = readMz3(fileName)
 %inputs:
 %	filename: the nv file to open
 %outputs:

--- a/matlab/private/readPly.m
+++ b/matlab/private/readPly.m
@@ -1,0 +1,491 @@
+function [faces, vertices, vertexColors] = readPly(filename)
+%Load a binary PLY format file, see writePly for format details
+% http://www.mathworks.com/matlabcentral/fileexchange/5355-toolbox-graph/content/toolbox_graph/read_ply.m
+% Gabriel Peyre 2004-2009
+%inputs:
+%	filename: the PLY file to open
+%outputs:
+%	faces: face matrix where cols are xyz and each row is face
+%	vertices: vertices matrix where cols are xyz and each row a vertix
+%   vertexColors: colors for each vertex
+
+% read_ply - read data from PLY file.
+%
+%   [vertex,face] = read_ply(filename);
+%
+%   'vertex' is a 'nb.vert x 3' array specifying the position of the vertices.
+%   'face' is a 'nb.face x 3' array specifying the connectivity of the mesh.
+%
+%   IMPORTANT: works only for triangular meshes.
+%
+%   Copyright (c) 2003 Gabriel Peyre 
+%     modified 2014 by Chris Rorden to import vertex colors
+
+vertexColors = [];
+[d,c] = plyread(filename);
+
+vi = d.face.vertex_indices;
+nf = length(vi);
+faces = zeros(nf,3);
+for i=1:nf
+    faces(i,:) = vi{i}+1;
+end
+vertices = [d.vertex.x, d.vertex.y, d.vertex.z];
+if isfield(d.vertex,'green')
+   vertexColors = [d.vertex.red d.vertex.green d.vertex.blue]/255;
+end
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function [Elements,varargout] = plyread(Path,Str)
+%PLYREAD   Read a PLY 3D data file.
+%   [DATA,COMMENTS] = PLYREAD(FILENAME) reads a version 1.0 PLY file
+%   FILENAME and returns a structure DATA.  The fields in this structure
+%   are defined by the PLY header; each element type is a field and each
+%   element property is a subfield.  If the file contains any comments,
+%   they are returned in a cell string array COMMENTS.
+%
+%   [TRI,PTS] = PLYREAD(FILENAME,'tri') or
+%   [TRI,PTS,DATA,COMMENTS] = PLYREAD(FILENAME,'tri') converts vertex
+%   and face data into triangular connectivity and vertex arrays.  The
+%   mesh can then be displayed using the TRISURF command.
+%
+%   Note: This function is slow for large mesh files (+50K faces),
+%   especially when reading data with list type properties.
+%
+%   Example:
+%   [Tri,Pts] = PLYREAD('cow.ply','tri');
+%   trisurf(Tri,Pts(:,1),Pts(:,2),Pts(:,3)); 
+%   colormap(gray); axis equal;
+%
+%   See also: PLYWRITE
+
+% Pascal Getreuer 2004
+
+[fid,Msg] = fopen(Path,'rt');	% open file in read text mode
+
+if fid == -1, error(Msg); end
+
+Buf = fscanf(fid,'%s',1);
+if ~strcmp(Buf,'ply')
+   fclose(fid);
+   error('Not a PLY file.'); 
+end
+
+
+%%% read header %%%
+
+Position = ftell(fid);
+Format = '';
+NumComments = 0;
+Comments = {};				% for storing any file comments
+NumElements = 0;
+NumProperties = 0;
+Elements = [];				% structure for holding the element data
+ElementCount = [];		% number of each type of element in file
+PropertyTypes = [];		% corresponding structure recording property types
+ElementNames = {};		% list of element names in the order they are stored in the file
+PropertyNames = [];		% structure of lists of property names
+
+while 1
+   Buf = fgetl(fid);   								% read one line from file
+   BufRem = Buf;
+   Token = {};
+   Count = 0;
+   
+   while ~isempty(BufRem)								% split line into tokens
+      [tmp,BufRem] = strtok(BufRem);
+      
+      if ~isempty(tmp)
+         Count = Count + 1;							% count tokens
+         Token{Count} = tmp;
+      end
+   end
+   
+   if Count 		% parse line
+      switch lower(Token{1})
+      case 'format'		% read data format
+         if Count >= 2
+            Format = lower(Token{2});
+            
+            if Count == 3 & ~strcmp(Token{3},'1.0')
+               fclose(fid);
+               error('Only PLY format version 1.0 supported.');
+            end
+         end
+      case 'comment'		% read file comment
+         NumComments = NumComments + 1;
+         Comments{NumComments} = '';
+         for i = 2:Count
+            Comments{NumComments} = [Comments{NumComments},Token{i},' '];
+         end
+      case 'element'		% element name
+         if Count >= 3
+            if isfield(Elements,Token{2})
+               fclose(fid);
+               error(['Duplicate element name, ''',Token{2},'''.']);
+            end
+            
+            NumElements = NumElements + 1;
+            NumProperties = 0;
+   	      Elements = setfield(Elements,Token{2},[]);
+            PropertyTypes = setfield(PropertyTypes,Token{2},[]);
+            ElementNames{NumElements} = Token{2};
+            PropertyNames = setfield(PropertyNames,Token{2},{});
+            CurElement = Token{2};
+            ElementCount(NumElements) = str2double(Token{3});
+            
+            if isnan(ElementCount(NumElements))
+               fclose(fid);
+               error(['Bad element definition: ',Buf]); 
+            end            
+         else
+            error(['Bad element definition: ',Buf]);
+         end         
+      case 'property'	% element property
+         if ~isempty(CurElement) & Count >= 3            
+            NumProperties = NumProperties + 1;
+            eval(['tmp=isfield(Elements.',CurElement,',Token{Count});'],...
+               'fclose(fid);error([''Error reading property: '',Buf])');
+            
+            if tmp
+               error(['Duplicate property name, ''',CurElement,'.',Token{2},'''.']);
+            end            
+            
+            % add property subfield to Elements
+            eval(['Elements.',CurElement,'.',Token{Count},'=[];'], ...
+               'fclose(fid);error([''Error reading property: '',Buf])');            
+            % add property subfield to PropertyTypes and save type
+            eval(['PropertyTypes.',CurElement,'.',Token{Count},'={Token{2:Count-1}};'], ...
+               'fclose(fid);error([''Error reading property: '',Buf])');            
+            % record property name order 
+            eval(['PropertyNames.',CurElement,'{NumProperties}=Token{Count};'], ...
+               'fclose(fid);error([''Error reading property: '',Buf])');
+         else
+            fclose(fid);
+            
+            if isempty(CurElement)            
+               error(['Property definition without element definition: ',Buf]);
+            else               
+               error(['Bad property definition: ',Buf]);
+            end            
+         end         
+      case 'end_header'	% end of header, break from while loop
+         break;		
+      end
+   end
+end
+
+%%% set reading for specified data format %%%
+
+if isempty(Format)
+	warning('Data format unspecified, assuming ASCII.');
+   Format = 'ascii';
+end
+
+switch Format
+case 'ascii'
+   Format = 0;
+case 'binary_little_endian'
+   Format = 1;
+case 'binary_big_endian'
+   Format = 2;
+otherwise
+   fclose(fid);
+   error(['Data format ''',Format,''' not supported.']);
+end
+
+if ~Format   
+   Buf = fscanf(fid,'%f');		% read the rest of the file as ASCII data
+   BufOff = 1;
+else
+   % reopen the file in read binary mode
+   fclose(fid);
+   
+   if Format == 1
+      fid = fopen(Path,'r','ieee-le.l64');		% little endian
+   else
+      fid = fopen(Path,'r','ieee-be.l64');		% big endian
+   end
+   
+   % find the end of the header again (using ftell on the old handle doesn't give the correct position)   
+   BufSize = 8192;
+   Buf = [blanks(10),char(fread(fid,BufSize,'uchar')')];
+   i = [];
+   tmp = -11;
+   
+   while isempty(i)
+   	i = findstr(Buf,['end_header',13,10]);			% look for end_header + CR/LF
+   	i = [i,findstr(Buf,['end_header',10])];		% look for end_header + LF
+      
+      if isempty(i)
+         tmp = tmp + BufSize;
+         Buf = [Buf(BufSize+1:BufSize+10),char(fread(fid,BufSize,'uchar')')];
+      end
+   end
+   
+   % seek to just after the line feed
+   fseek(fid,i + tmp + 11 + (Buf(i + 10) == 13),-1);
+end
+
+
+%%% read element data %%%
+
+% PLY and MATLAB data types (for fread)
+PlyTypeNames = {'char','uchar','short','ushort','int','uint','float','double', ...
+   'char8','uchar8','short16','ushort16','int32','uint32','float32','double64'};
+MatlabTypeNames = {'schar','uchar','int16','uint16','int32','uint32','single','double'};
+SizeOf = [1,1,2,2,4,4,4,8];	% size in bytes of each type
+
+for i = 1:NumElements
+   % get current element property information
+   eval(['CurPropertyNames=PropertyNames.',ElementNames{i},';']);
+   eval(['CurPropertyTypes=PropertyTypes.',ElementNames{i},';']);
+   NumProperties = size(CurPropertyNames,2);
+   
+%   fprintf('Reading %s...\n',ElementNames{i});
+      
+   if ~Format	%%% read ASCII data %%%
+      for j = 1:NumProperties
+         Token = getfield(CurPropertyTypes,CurPropertyNames{j});
+         
+         if strcmpi(Token{1},'list')
+            Type(j) = 1;
+         else
+            Type(j) = 0;
+			end
+      end
+      
+      % parse buffer
+      if ~any(Type)
+         % no list types
+         Data = reshape(Buf(BufOff:BufOff+ElementCount(i)*NumProperties-1),NumProperties,ElementCount(i))';
+         BufOff = BufOff + ElementCount(i)*NumProperties;
+      else
+         ListData = cell(NumProperties,1);
+         
+         for k = 1:NumProperties
+            ListData{k} = cell(ElementCount(i),1);
+         end
+         
+         % list type
+		   for j = 1:ElementCount(i)
+   	      for k = 1:NumProperties
+      	      if ~Type(k)
+         	      Data(j,k) = Buf(BufOff);
+            	   BufOff = BufOff + 1;
+	            else
+   	            tmp = Buf(BufOff);
+      	         ListData{k}{j} = Buf(BufOff+(1:tmp))';
+         	      BufOff = BufOff + tmp + 1;
+            	end
+            end
+         end
+      end
+   else		%%% read binary data %%%
+      % translate PLY data type names to MATLAB data type names
+      ListFlag = 0;		% = 1 if there is a list type 
+      SameFlag = 1;     % = 1 if all types are the same
+      
+      for j = 1:NumProperties
+         Token = getfield(CurPropertyTypes,CurPropertyNames{j});
+         
+         if ~strcmp(Token{1},'list')			% non-list type
+	         tmp = rem(strmatch(Token{1},PlyTypeNames,'exact')-1,8)+1;
+         
+            if ~isempty(tmp)
+               TypeSize(j) = SizeOf(tmp);
+               Type{j} = MatlabTypeNames{tmp};
+               TypeSize2(j) = 0;
+               Type2{j} = '';
+               
+               SameFlag = SameFlag & strcmp(Type{1},Type{j});
+	         else
+   	         fclose(fid);
+               error(['Unknown property data type, ''',Token{1},''', in ', ...
+                     ElementNames{i},'.',CurPropertyNames{j},'.']);
+         	end
+         else											% list type
+            if length(Token) == 3
+               ListFlag = 1;
+               SameFlag = 0;
+               tmp = rem(strmatch(Token{2},PlyTypeNames,'exact')-1,8)+1;
+               tmp2 = rem(strmatch(Token{3},PlyTypeNames,'exact')-1,8)+1;
+         
+               if ~isempty(tmp) & ~isempty(tmp2)
+                  TypeSize(j) = SizeOf(tmp);
+                  Type{j} = MatlabTypeNames{tmp};
+                  TypeSize2(j) = SizeOf(tmp2);
+                  Type2{j} = MatlabTypeNames{tmp2};
+	   	      else
+   	   	      fclose(fid);
+               	error(['Unknown property data type, ''list ',Token{2},' ',Token{3},''', in ', ...
+                        ElementNames{i},'.',CurPropertyNames{j},'.']);
+               end
+            else
+               fclose(fid);
+               error(['Invalid list syntax in ',ElementNames{i},'.',CurPropertyNames{j},'.']);
+            end
+         end
+      end
+      
+      % read file
+      if ~ListFlag
+         if SameFlag
+            % no list types, all the same type (fast)
+            Data = fread(fid,[NumProperties,ElementCount(i)],Type{1})';
+         else
+            % no list types, mixed type
+            Data = zeros(ElementCount(i),NumProperties);
+            
+         	for j = 1:ElementCount(i)
+        			for k = 1:NumProperties
+               	Data(j,k) = fread(fid,1,Type{k});
+              	end
+         	end
+         end
+      else
+         ListData = cell(NumProperties,1);
+         
+         for k = 1:NumProperties
+            ListData{k} = cell(ElementCount(i),1);
+         end
+         
+         if NumProperties == 1
+            BufSize = 512;
+            SkipNum = 4;
+            j = 0;
+            
+            % list type, one property (fast if lists are usually the same length)
+            while j < ElementCount(i)
+               Position = ftell(fid);
+               % read in BufSize count values, assuming all counts = SkipNum
+               [Buf,BufSize] = fread(fid,BufSize,Type{1},SkipNum*TypeSize2(1));
+               Miss = find(Buf ~= SkipNum);					% find first count that is not SkipNum
+               fseek(fid,Position + TypeSize(1),-1); 		% seek back to after first count                              
+               
+               if isempty(Miss)									% all counts are SkipNum
+                  Buf = fread(fid,[SkipNum,BufSize],[int2str(SkipNum),'*',Type2{1}],TypeSize(1))';
+                  fseek(fid,-TypeSize(1),0); 				% undo last skip
+                  
+                  for k = 1:BufSize
+                     ListData{1}{j+k} = Buf(k,:);
+                  end
+                  
+                  j = j + BufSize;
+                  BufSize = floor(1.5*BufSize);
+               else
+                  if Miss(1) > 1									% some counts are SkipNum
+                     Buf2 = fread(fid,[SkipNum,Miss(1)-1],[int2str(SkipNum),'*',Type2{1}],TypeSize(1))';                     
+                     
+                     for k = 1:Miss(1)-1
+                        ListData{1}{j+k} = Buf2(k,:);
+                     end
+                     
+                     j = j + k;
+                  end
+                  
+                  % read in the list with the missed count
+                  SkipNum = Buf(Miss(1));
+                  j = j + 1;
+                  ListData{1}{j} = fread(fid,[1,SkipNum],Type2{1});
+                  BufSize = ceil(0.6*BufSize);
+               end
+            end
+         else
+            % list type(s), multiple properties (slow)
+            Data = zeros(ElementCount(i),NumProperties);
+            
+            for j = 1:ElementCount(i)
+         		for k = 1:NumProperties
+            		if isempty(Type2{k})
+               		Data(j,k) = fread(fid,1,Type{k});
+            		else
+               		tmp = fread(fid,1,Type{k});
+               		ListData{k}{j} = fread(fid,[1,tmp],Type2{k});
+		            end
+      		   end
+      		end
+         end
+      end
+   end
+   
+   % put data into Elements structure
+   for k = 1:NumProperties
+   	if (~Format & ~Type(k)) | (Format & isempty(Type2{k}))
+      	eval(['Elements.',ElementNames{i},'.',CurPropertyNames{k},'=Data(:,k);']);
+      else
+      	eval(['Elements.',ElementNames{i},'.',CurPropertyNames{k},'=ListData{k};']);
+		end
+   end
+end
+
+clear Data ListData;
+fclose(fid);
+
+if (nargin > 1 & strcmpi(Str,'Tri')) | nargout > 2   
+   % find vertex element field
+   Name = {'vertex','Vertex','point','Point','pts','Pts'};
+   Names = [];
+   
+   for i = 1:length(Name)
+      if any(strcmp(ElementNames,Name{i}))
+         Names = getfield(PropertyNames,Name{i});
+         Name = Name{i};         
+         break;
+      end
+   end
+   
+   if any(strcmp(Names,'x')) & any(strcmp(Names,'y')) & any(strcmp(Names,'z'))
+      eval(['varargout{1}=[Elements.',Name,'.x,Elements.',Name,'.y,Elements.',Name,'.z];']);
+   else
+      varargout{1} = zeros(1,3);
+	end
+           
+   varargout{2} = Elements;
+   varargout{3} = Comments;
+   Elements = [];
+   
+   % find face element field
+   Name = {'face','Face','poly','Poly','tri','Tri'};
+   Names = [];
+   
+   for i = 1:length(Name)
+      if any(strcmp(ElementNames,Name{i}))
+         Names = getfield(PropertyNames,Name{i});
+         Name = Name{i};
+         break;
+      end
+   end
+   
+   if ~isempty(Names)
+      % find vertex indices property subfield
+	   PropertyName = {'vertex_indices','vertex_indexes','vertex_index','indices','indexes'};           
+      
+   	for i = 1:length(PropertyName)
+      	if any(strcmp(Names,PropertyName{i}))
+         	PropertyName = PropertyName{i};
+	         break;
+   	   end
+      end
+      
+      if ~iscell(PropertyName)
+         % convert face index lists to triangular connectivity
+         eval(['FaceIndices=varargout{2}.',Name,'.',PropertyName,';']);
+  			N = length(FaceIndices);
+   		Elements = zeros(N*2,3);
+   		Extra = 0;   
+
+			for k = 1:N
+   			Elements(k,:) = FaceIndices{k}(1:3);
+   
+   			for j = 4:length(FaceIndices{k})
+      			Extra = Extra + 1;      
+	      		Elements(N + Extra,:) = [Elements(k,[1,j-1]),FaceIndices{k}(j)];
+   			end
+         end
+         Elements = Elements(1:N+Extra,:) + 1;
+      end
+   end
+else
+   varargout{1} = Comments;
+end

--- a/meshtest.js
+++ b/meshtest.js
@@ -8,6 +8,7 @@ const gifti = require('gifti-reader-js')
 const fflate = require('fflate')
 const jd = require('./lib/jdata.js')
 const bjd = require('bjd')
+const util= require('util');
 global.atob = require("atob");
 
 function readPLY(buffer) {
@@ -21,7 +22,7 @@ function readPLY(buffer) {
     while (pos < len && bytes[pos] !== 10) pos++;
     pos++; //skip EOLN
     if (pos - startPos < 1) return "";
-    return new TextDecoder().decode(buffer.slice(startPos, pos - 1));
+    return new util.TextDecoder().decode(buffer.slice(startPos, pos - 1));
   }
   let line = readStr(); //1st line: magic 'ply'
   if (!line.startsWith("ply")) {

--- a/python/meshtest.py
+++ b/python/meshtest.py
@@ -1,0 +1,91 @@
+"""meshtest.py - loading speed benchmark for various triangular-mesh file formats
+
+This module test the parsing speed for various commonly used and emerging surface
+mesh file formats. Along with the benchmarks for JavaScript and MATLAB, this script
+provides a meaningful comparison on the trade-offs between file sizes and parsing speed
+offered by using different mesh formats. Additionally, similar to the sample scripts
+for JavaScript and MATLAB, this script provides a simple list of file loading/parsing
+commands to use these formats in Python.
+
+To run this script, one should install the below dependencies via pip
+
+    python3 -mpip install nibabel jdata bjdata numpy-stl meshio numpy
+
+Then one can simply run
+
+    python3 meshtest.py
+
+inside the current folder.
+
+Author: Qianqian Fang <q.fang at neu.edu>
+
+"""
+
+import nibabel as nib           # read .gii
+import jdata as jd              # read .jmsh, .bmsh
+import json                     # read .json
+import mz3                      # read .mz3
+import stl                      # read .stl
+import meshio                   # read .obj
+
+import os
+import time
+
+files=["gz.gii", "gz.mz3", "raw.mz3", "obj.obj", "stl.stl", "zlib.jmsh", "zlib.bmsh", "raw.min.json", "raw.bmsh"] #"lzma.bmsh"
+
+def loadmeshx10(fname):
+    filename=os.getcwd() + '/../meshes/'+fname
+    expectednode=163842
+    expectedface=327680
+
+    # repeating 10 times, and measure the total run-times for the last 9 iterations
+    for x in range(0, 10):
+        if(x==1):
+            t=time.time()
+        points, tris = loadmesh(filename)
+
+    runtime=(time.time()-t)*1000
+    print("{}\t{}".format(fname, runtime))
+
+    if(fname.find(".stl")<0 and len(points)!=expectednode and len(points)!=expectednode*3):
+        print("node size mismatch: expected {}, got {}".format(expectednode,len(points)))
+    if(len(tris)!=expectedface and len(tris)!=expectedface*3):
+        print("face size mismatch: expected {}, got {}".format(expectedface,len(tris)))
+    return runtime
+
+def loadmesh(filename):
+    ext=os.path.splitext(filename)[-1];
+    points=[]
+    tris=[]
+    if(ext=='.gii'):
+        obj = nib.load(filename)
+        tris, points= obj.agg_data()
+    elif(ext == '.mz3'):
+        points, tris = mz3.load_mz3_mesh(filename, False)
+    elif(ext == '.stl'):
+        obj = stl.mesh.Mesh.from_file(filename)
+        points = obj.points
+        tris = obj.vectors
+    elif(ext == '.obj'):  # or .obj, .off, .vtk, .ply, ..., but slow
+        obj = meshio.read(filename)
+        points = obj.points
+        tris = obj.cells[0].data
+    elif(ext == '.jmsh' or ext == '.bmsh'):
+        obj = jd.load(filename)
+        points = obj['MeshVertex3']
+        tris = obj['MeshTri3']
+    elif(ext == '.json'):
+        with open(filename, 'r') as fp:
+            obj = json.load(fp)
+        points = obj['MeshVertex3']
+        tris = obj['MeshTri3']
+    else:
+        print('skipping file'+fname)
+        return points, tris
+    return points, tris
+
+
+# run benchmark
+res=map(loadmeshx10, files)
+runtimes=list(res)
+

--- a/python/meshtest.py
+++ b/python/meshtest.py
@@ -32,7 +32,7 @@ import meshio                   # read .obj
 import os
 import time
 
-files=["gz.gii", "gz.mz3", "raw.mz3", "obj.obj", "stl.stl", "zlib.jmsh", "zlib.bmsh", "raw.min.json", "raw.bmsh"] #"lzma.bmsh"
+files=["obj.obj", "gz.gii",  "raw.gii", "ply.ply", "gz.mz3", "raw.mz3",  "stl.stl", "zlib.jmsh", "zlib.bmsh", "raw.min.json", "raw.bmsh"] #"lzma.bmsh"
 
 def loadmeshx10(fname):
     filename=os.getcwd() + '/../meshes/'+fname
@@ -67,7 +67,7 @@ def loadmesh(filename):
         obj = stl.mesh.Mesh.from_file(filename)
         points = obj.points
         tris = obj.vectors
-    elif(ext == '.obj'):  # or .obj, .off, .vtk, .ply, ..., but slow
+    elif(ext == '.obj' or ext == '.ply'):  # or .obj, .off, .vtk, .ply, ..., but slow
         obj = meshio.read(filename)
         points = obj.points
         tris = obj.cells[0].data

--- a/python/meshtest.py
+++ b/python/meshtest.py
@@ -9,7 +9,7 @@ commands to use these formats in Python.
 
 To run this script, one should install the below dependencies via pip
 
-    python3 -mpip install nibabel jdata bjdata numpy-stl meshio numpy yyjson
+    python3 -mpip install nibabel jdata bjdata numpy-stl meshio numpy pysimdjson
 
 Then one can simply run
 
@@ -24,7 +24,7 @@ Author: Qianqian Fang <q.fang at neu.edu>
 import nibabel as nib           # read .gii
 import jdata as jd              # read .jmsh, .bmsh
 #import json                     # read .json
-import yyjson                   # read .json
+import simdjson                 # read .json
 import mz3                      # read .mz3
 import stl                      # read .stl
 import meshio                   # read .obj
@@ -76,8 +76,9 @@ def loadmesh(filename):
         points = obj['MeshVertex3']
         tris = obj['MeshTri3']
     elif(ext == '.json'):
+        parser = simdjson.Parser()
         with open(filename, 'r') as fp:
-            obj = yyjson.load(fp)
+            obj = parser.parse(fp.read())
         points = obj['MeshVertex3']
         tris = obj['MeshTri3']
     else:

--- a/python/meshtest.py
+++ b/python/meshtest.py
@@ -9,7 +9,7 @@ commands to use these formats in Python.
 
 To run this script, one should install the below dependencies via pip
 
-    python3 -mpip install nibabel jdata bjdata numpy-stl meshio numpy
+    python3 -mpip install nibabel jdata bjdata numpy-stl meshio numpy yyjson
 
 Then one can simply run
 
@@ -23,7 +23,8 @@ Author: Qianqian Fang <q.fang at neu.edu>
 
 import nibabel as nib           # read .gii
 import jdata as jd              # read .jmsh, .bmsh
-import json                     # read .json
+#import json                     # read .json
+import yyjson                   # read .json
 import mz3                      # read .mz3
 import stl                      # read .stl
 import meshio                   # read .obj
@@ -76,7 +77,7 @@ def loadmesh(filename):
         tris = obj['MeshTri3']
     elif(ext == '.json'):
         with open(filename, 'r') as fp:
-            obj = json.load(fp)
+            obj = yyjson.load(fp)
         points = obj['MeshVertex3']
         tris = obj['MeshTri3']
     else:

--- a/python/mz3/__init__.py
+++ b/python/mz3/__init__.py
@@ -1,0 +1,10 @@
+from .mz3 import load_mz3_mesh
+
+__version__ = '0.1.0'
+__all__ = ['load_mz3_mesh']
+__license__ = """https://github.com/neurolabusc/surf-ice/blob/master/mz3/mz3.py"""
+
+
+if __name__ == '__main__':
+    import cmd
+    cmd.main()

--- a/python/mz3/mz3.py
+++ b/python/mz3/mz3.py
@@ -1,3 +1,6 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
 """mz3 module
 
 This module is reformatted from https://github.com/neurolabusc/surf-ice/blob/master/mz3/mz3.py
@@ -11,9 +14,12 @@ __all__ = ['load_mz3_mesh']
 
 import struct
 import gzip
+import numpy as np
+import os
+
 
 ##====================================================================================
-## 
+##
 ##====================================================================================
 
 def read(fnm, isVerbose):
@@ -23,102 +29,130 @@ def read(fnm, isVerbose):
     rbga = []
     scalar = []
     with open(fnm, 'rb') as f:
-        hdrBytes = 16
-        data = f.read(hdrBytes)
-        # header is 16 bytes LITTLE-ENDIAN
-        #  UINT16 : MAGIC
-        #  UINT16 : ATTR
-        #  UINT32 : NFACE
-        #  UINT32 : NVERT
-        #  UINT32 : NSKIP
-        hdr = struct.unpack_from('<HHIII', data)
-        if hdr[0] != 23117:  # incorrect magic: assume gzip
-            f = gzip.open(fnm, 'rb')
-            data = f.read(hdrBytes)
-            hdr = struct.unpack_from('<HHIII', data)
-            if hdr[0] != 23117:  # incorrect magic: not mz3
-                print("Not a valid MZ3 file")
+        MAGIC = np.fromfile(f, '<u2', 1)[0]
+        isGz = False
+        if MAGIC != 23117:  # incorrect magic: assume gzip
+            isGz = True
+            fz = bytearray(gzip.open(fnm, 'r').read())
+            MAGIC = np.frombuffer(fz, '<u2', 1, 0)[0]
+            if MAGIC != 23117:
+                print('Not a valid MZ3 file')
                 return invalid_mz3
-            if isVerbose:
-                print("GZ Compressed")
-        MAGIC = hdr[0]
-        ATTR = hdr[1]
-        NFACE = hdr[2]
-        NVERT = hdr[3]
-        NSKIP = hdr[4]
-        # read attributes
-        isFACE = (ATTR & 1) != 0
-        isVERT = (ATTR & 2) != 0
-        isRGBA = (ATTR & 4) != 0
-        isSCALAR = (ATTR & 8) != 0
-        # report contents
+            ATTR = np.frombuffer(fz, '<u2', 1, 2)[0]
+            NFACE = np.frombuffer(fz, '<u4', 1, 4)[0]
+            NVERT = np.frombuffer(fz, '<u4', 1, 8)[0]
+            NSKIP = np.frombuffer(fz, '<u4', 1, 16)[0]
+            isFACE = ATTR & 1 != 0
+            isVERT = ATTR & 2 != 0
+            isRGBA = ATTR & 4 != 0
+            isSCALAR = ATTR & 8 != 0
+
+            # quit if file does not make sense
+
+            if ATTR > 15:
+                print('Unable to read future version of MZ3 file')
+                return invalid_mz3
+            if NVERT < 1:
+                print('Unable to read MZ3 files without vertices')
+                return invalid_mz3
+            if (NFACE < 1) & isFACE:
+                print('MZ3 files with isFACE must specify NFACE')
+                return invalid_mz3
+            pos = 16 + NSKIP  # data
+            if isFACE:  # each face is 3 UINT32 vertex indices
+                faces = np.frombuffer(fz, '<u4', NFACE * 3, pos)
+                pos += NFACE * 12
+            if isVERT:  # each vertex is 3 FLOAT32 (xyz)
+                verts = np.frombuffer(fz, '<f4', NVERT * 3, pos)
+                pos += NVERT * 12
+            if isRGBA:  # each vertex has UINT32 RGBA value
+                rbga = np.frombuffer(fz, '<u4', NVERT, pos)
+                pos += NVERT * 4
+            if isSCALAR:
+                fz.seek(0, os.SEEK_END)
+                NSCALAR = np.floor((len(fz) - pos) / (NVERT
+                                   * 4)).astype(int)
+                verts = np.frombuffer(fz, '<f4', NVERT * NSCALAR, pos)
+                pos += NVERT * NSCALAR * 4
+        else:
+
+            # read attributes
+
+            ATTR = np.fromfile(f, '<u2', 1)[0]
+            NFACE = np.fromfile(f, '<u4', 1)[0]
+            NVERT = np.fromfile(f, '<u4', 1)[0]
+            NSKIP = np.fromfile(f, '<u4', 1)[0]
+            isFACE = ATTR & 1 != 0
+            isVERT = ATTR & 2 != 0
+            isRGBA = ATTR & 4 != 0
+            isSCALAR = ATTR & 8 != 0
+
+            # quit if file does not make sense
+
+            if ATTR > 15:
+                print('Unable to read future version of MZ3 file')
+                return invalid_mz3
+            if NVERT < 1:
+                print('Unable to read MZ3 files without vertices')
+                return invalid_mz3
+            if (NFACE < 1) & isFACE:
+                print('MZ3 files with isFACE must specify NFACE')
+                return invalid_mz3
+            pos = 16 + NSKIP  # data
+            if NSKIP > 0:  # skip bytes
+                skip = np.fromfile(f, '<u8', NSKIP)
+            if isFACE:  # each face is 3 UINT32 vertex indices
+                faces = np.fromfile(f, '<u4', NFACE * 3)
+                pos += NFACE * 12
+            if isVERT:  # each vertex is 3 FLOAT32 (xyz)
+                verts = np.fromfile(f, '<f4', NVERT * 3)
+                pos += NVERT * 12
+            if isRGBA:  # each vertex has UINT32 RGBA value
+                rbga = np.fromfile(f, '<u4', NVERT)
+                pos += NVERT * 4
+            if isSCALAR:
+                f.seek(0, os.SEEK_END)
+                NSCALAR = np.floor((f.tell() - pos) / (NVERT
+                                   * 4)).astype(int)
+                verts = np.fromfile(f, '<f4', NVERT * NSCALAR)
+                pos += NVERT * NSCALAR * 4
+
+        # Optional verbose reporting
+            # report contents
+
         if isVerbose:
-            print("MAGIC %d ATTR %d" % (MAGIC, ATTR))
-            print("NFACE %d NVERT %d NSKIP %d" % (NFACE, NVERT, NSKIP))
-            print(" isFACE %r isVERT %r" % (isFACE, isVERT))
-            print(" isRGBA %r isSCALAR %r" % (isRGBA, isSCALAR))
-        # quit if file does not make sense
-        if ATTR > 15:
-            print("Unable to read future version of MZ3 file")
-            return invalid_mz3
-        if NVERT < 1:
-            print("Unable to read MZ3 files without vertices")
-            return invalid_mz3
-        if (NFACE < 1) & (isFACE):
-            print("MZ3 files with isFACE must specify NFACE")
-            return invalid_mz3
-        # read faces
-        f.seek(hdrBytes+NSKIP)
-        if isFACE:
-            data = f.read(12 * NFACE)  # each face is 3 UINT32 vertex indices
-            str = '<{}I'.format(3*NFACE)
-            faces = struct.unpack_from(str, data)
-        # read vertices
-        f.seek(hdrBytes+NSKIP+(isFACE * NFACE * 3 * 4))
-        if isVERT:
-            data = f.read(12 * NVERT)  # each vertex is 3 FLOAT32 (xyz)
-            str = '<{}f'.format(3*NVERT)
-            verts = struct.unpack_from(str, data)
-        # read RGBA colors
-        f.seek(hdrBytes+NSKIP+(isFACE * NFACE * 12)+(isVERT * NVERT * 12))
-        if isRGBA:
-            data = f.read(4 * NVERT)  # each vertex has UINT32 RGBA value
-            str = '<{}I'.format(NVERT)
-            rbga = struct.unpack_from(str, data)
-        # read Scalar Intensity
-        f.seek(hdrBytes+NSKIP+(isFACE * NFACE * 12)
-               + (isVERT * NVERT * 12)+(isRGBA * NVERT * 4))
-        if isSCALAR:
-            data = f.read(4 * NVERT)  # each vertex has FLOAT32 scalar value
-            str = '<{}f'.format(NVERT)
-            scalar = struct.unpack_from(str, data)
-    # Optional verbose reporting
-    if isVerbose & (len(faces) > 0):
-        NFACE = len(faces) // 3
-        j = 0
-        for i in range(NFACE):
-            print("%d face %d %d %d" % (i, faces[j], faces[j+1], faces[j+2]))
-            j = j + 3
-    if isVerbose & (len(verts) > 0):
-        NVERT = len(verts) // 3
-        j = 0
-        for i in range(NVERT):
-            print("%d vert %g %g %g" % (i, verts[j], verts[j+1], verts[j+2]))
-            j = j + 3
-    if isVerbose & (len(rbga) > 0):
-        for i in range(len(rbga)):
-            rgba = struct.unpack("4B", struct.pack("I", rbga[i]))
-            print("%d rgba %d %d %d %d" % (i, rgba[0],
-                                           rgba[1], rgba[2], rgba[3]))
-    if isVerbose & (len(scalar) > 0):
-        for i in range(len(scalar)):
-            print("%d scalar %g" % (i, scalar[i]))
-    return faces, verts, rbga, scalar
+            print('MAGIC %d ATTR %d' % (MAGIC, ATTR))
+            print('NFACE %d NVERT %d NSKIP %d' % (NFACE, NVERT, NSKIP))
+            print(' isFACE %r isVERT %r' % (isFACE, isVERT))
+            print(' isRGBA %r isSCALAR %r' % (isRGBA, isSCALAR))
+        if isVerbose & (len(faces) > 0):
+            NFACE = len(faces) // 3
+            j = 0
+            for i in range(NFACE):
+                print('%d face %d %d %d' % (i, faces[j], faces[j + 1],
+                        faces[j + 2]))
+                j = j + 3
+        if isVerbose & (len(verts) > 0):
+            NVERT = len(verts) // 3
+            j = 0
+            for i in range(NVERT):
+                print('%d vert %g %g %g' % (i, verts[j], verts[j + 1],
+                        verts[j + 2]))
+                j = j + 3
+        if isVerbose & (len(rbga) > 0):
+            for i in range(len(rbga)):
+                rgba = struct.unpack('4B', struct.pack('I', rbga[i]))
+                print('%d rgba %d %d %d %d' % (i, rgba[0], rgba[1],
+                        rgba[2], rgba[3]))
+        if isVerbose & (len(scalar) > 0):
+            for i in range(len(scalar)):
+                print('%d scalar %g' % (i, scalar[i]))
+        return (faces, verts, rbga, scalar)
 
 
 def load_mz3_mesh(filepath, isVerbose):
-    faces, verts, rbga, scalar = read(filepath, isVerbose)
+    (faces, verts, rbga, scalar) = read(filepath, isVerbose)
     if verts is None:
         print('Invalid file')
         return
-    return verts, faces
+    return (verts, faces)

--- a/python/mz3/mz3.py
+++ b/python/mz3/mz3.py
@@ -1,0 +1,124 @@
+"""mz3 module
+
+This module is reformatted from https://github.com/neurolabusc/surf-ice/blob/master/mz3/mz3.py
+"""
+
+__all__ = ['load_mz3_mesh']
+
+##====================================================================================
+## dependent libraries
+##====================================================================================
+
+import struct
+import gzip
+
+##====================================================================================
+## 
+##====================================================================================
+
+def read(fnm, isVerbose):
+    invalid_mz3 = (None, None, None, None)
+    faces = []
+    verts = []
+    rbga = []
+    scalar = []
+    with open(fnm, 'rb') as f:
+        hdrBytes = 16
+        data = f.read(hdrBytes)
+        # header is 16 bytes LITTLE-ENDIAN
+        #  UINT16 : MAGIC
+        #  UINT16 : ATTR
+        #  UINT32 : NFACE
+        #  UINT32 : NVERT
+        #  UINT32 : NSKIP
+        hdr = struct.unpack_from('<HHIII', data)
+        if hdr[0] != 23117:  # incorrect magic: assume gzip
+            f = gzip.open(fnm, 'rb')
+            data = f.read(hdrBytes)
+            hdr = struct.unpack_from('<HHIII', data)
+            if hdr[0] != 23117:  # incorrect magic: not mz3
+                print("Not a valid MZ3 file")
+                return invalid_mz3
+            if isVerbose:
+                print("GZ Compressed")
+        MAGIC = hdr[0]
+        ATTR = hdr[1]
+        NFACE = hdr[2]
+        NVERT = hdr[3]
+        NSKIP = hdr[4]
+        # read attributes
+        isFACE = (ATTR & 1) != 0
+        isVERT = (ATTR & 2) != 0
+        isRGBA = (ATTR & 4) != 0
+        isSCALAR = (ATTR & 8) != 0
+        # report contents
+        if isVerbose:
+            print("MAGIC %d ATTR %d" % (MAGIC, ATTR))
+            print("NFACE %d NVERT %d NSKIP %d" % (NFACE, NVERT, NSKIP))
+            print(" isFACE %r isVERT %r" % (isFACE, isVERT))
+            print(" isRGBA %r isSCALAR %r" % (isRGBA, isSCALAR))
+        # quit if file does not make sense
+        if ATTR > 15:
+            print("Unable to read future version of MZ3 file")
+            return invalid_mz3
+        if NVERT < 1:
+            print("Unable to read MZ3 files without vertices")
+            return invalid_mz3
+        if (NFACE < 1) & (isFACE):
+            print("MZ3 files with isFACE must specify NFACE")
+            return invalid_mz3
+        # read faces
+        f.seek(hdrBytes+NSKIP)
+        if isFACE:
+            data = f.read(12 * NFACE)  # each face is 3 UINT32 vertex indices
+            str = '<{}I'.format(3*NFACE)
+            faces = struct.unpack_from(str, data)
+        # read vertices
+        f.seek(hdrBytes+NSKIP+(isFACE * NFACE * 3 * 4))
+        if isVERT:
+            data = f.read(12 * NVERT)  # each vertex is 3 FLOAT32 (xyz)
+            str = '<{}f'.format(3*NVERT)
+            verts = struct.unpack_from(str, data)
+        # read RGBA colors
+        f.seek(hdrBytes+NSKIP+(isFACE * NFACE * 12)+(isVERT * NVERT * 12))
+        if isRGBA:
+            data = f.read(4 * NVERT)  # each vertex has UINT32 RGBA value
+            str = '<{}I'.format(NVERT)
+            rbga = struct.unpack_from(str, data)
+        # read Scalar Intensity
+        f.seek(hdrBytes+NSKIP+(isFACE * NFACE * 12)
+               + (isVERT * NVERT * 12)+(isRGBA * NVERT * 4))
+        if isSCALAR:
+            data = f.read(4 * NVERT)  # each vertex has FLOAT32 scalar value
+            str = '<{}f'.format(NVERT)
+            scalar = struct.unpack_from(str, data)
+    # Optional verbose reporting
+    if isVerbose & (len(faces) > 0):
+        NFACE = len(faces) // 3
+        j = 0
+        for i in range(NFACE):
+            print("%d face %d %d %d" % (i, faces[j], faces[j+1], faces[j+2]))
+            j = j + 3
+    if isVerbose & (len(verts) > 0):
+        NVERT = len(verts) // 3
+        j = 0
+        for i in range(NVERT):
+            print("%d vert %g %g %g" % (i, verts[j], verts[j+1], verts[j+2]))
+            j = j + 3
+    if isVerbose & (len(rbga) > 0):
+        for i in range(len(rbga)):
+            rgba = struct.unpack("4B", struct.pack("I", rbga[i]))
+            print("%d rgba %d %d %d %d" % (i, rgba[0],
+                                           rgba[1], rgba[2], rgba[3]))
+    if isVerbose & (len(scalar) > 0):
+        for i in range(len(scalar)):
+            print("%d scalar %g" % (i, scalar[i]))
+    return faces, verts, rbga, scalar
+
+
+def load_mz3_mesh(filepath, isVerbose):
+    faces, verts, rbga, scalar = read(filepath, isVerbose)
+    if verts is None:
+        print('Invalid file')
+        return
+    return verts, faces


### PR DESCRIPTION
hi @neurolabusc, I added python benchmarking scripts in this PR. the results look like below on my Ryzen 4800H laptop

**Updated after applying the [mz3 optimization patch](https://github.com/NeuroJSON/MeshFormatsJS/pull/1) and [pysimdjson](https://github.com/neurolabusc/MeshFormatsJS/pull/6/commits/581f7486292fec8a63297fcafcf616c3bd6187e1)**
```
gz.gii	335.5226516723633
gz.mz3	234.13467407226562
raw.mz3	11.878490447998047
obj.obj	9367.066621780396
stl.stl	220.43609619140625
zlib.jmsh	319.6604251861572
zlib.bmsh	186.45715713500977
raw.min.json	343.52922439575195
raw.bmsh	32.37032890319824
```
Overall, the performances are among the best compared to JS/MATLAB (with the exception of OBJ).

I also updated [this spreadsheet](https://docs.google.com/spreadsheets/d/1huFjHl1T0WlMWzNxRpU2E5SVjZSC3xgwjf_LNG81Ik8/edit?usp=sharing). The plot is attached below. 

Two quick notes: 
- OBJ is too slow to be shown on the plot. 
- Also, Pyhon's `lzma` module failed to decode the lzma-compressed buffer stored in `lzma.bmsh`. I am still trying to figure out how to fix it.

![Python (Ubuntu 20 04, Ryzen 4800H) (1)](https://user-images.githubusercontent.com/226913/165001997-10d21463-4f88-43ca-88ac-be35205b4258.svg)

