### PR TITLE
Adding lzma.bmsh to python benchmark

### DIFF
--- a/python/meshtest.py
+++ b/python/meshtest.py
@@ -32,7 +32,7 @@ import meshio                   # read .obj
 import os
 import time
 
-files=["obj.obj", "gz.gii",  "raw.gii", "ply.ply", "gz.mz3", "raw.mz3",  "stl.stl", "zlib.jmsh", "zlib.bmsh", "raw.min.json", "raw.bmsh"] #"lzma.bmsh"
+files=["obj.obj", "gz.gii",  "raw.gii", "ply.ply", "gz.mz3", "raw.mz3",  "stl.stl", "zlib.jmsh", "zlib.bmsh", "raw.min.json", "raw.bmsh", "lzma.bmsh"]
 
 def loadmeshx10(fname):
     filename=os.getcwd() + '/../meshes/'+fname


### PR DESCRIPTION
The lzma decompression issue was fixed, see https://github.com/python/cpython/issues/92018

need to run `python3 -mpip install --upgrade jdata` to update jdata module to v0.4.1.

the results are updated in the [spreadsheet](https://docs.google.com/spreadsheets/d/1huFjHl1T0WlMWzNxRpU2E5SVjZSC3xgwjf_LNG81Ik8/edit?usp=sharing).

![Python (Ubuntu 20 04, Ryzen 4800H) (4)](https://user-images.githubusercontent.com/226913/166089748-40a43864-a14f-469e-bf04-0618af24b4c1.svg)

